### PR TITLE
Update URL for Owen's personal website

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As complementary material,
 
 - These lecture [notes](https://web.archive.org/web/20131215003910/https://statweb.stanford.edu/~susan/courses/s227/)  by stellar statistician [Susan Holmes](https://statweb.stanford.edu/~susan/) are also well worth taking a look.
 
-- [Monte Carlo theory, methods and examples](https://statweb.stanford.edu/~owen/mc/) by [Professor Art Owen](https://statweb.stanford.edu/~owen/), gives a nice and complete treatment of all the topics on simulation, including a whole chapter on variance reduction. 
+- [Monte Carlo theory, methods and examples](https://artowen.su.domains/mc/) by [Professor Art Owen](https://statweb.stanford.edu/~owen/), gives a nice and complete treatment of all the topics on simulation, including a whole chapter on variance reduction. 
 
 Other materials, including lecture notes and slides may be posted here as the course progresses. 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As complementary material,
 
 - These lecture [notes](https://web.archive.org/web/20131215003910/https://statweb.stanford.edu/~susan/courses/s227/)  by stellar statistician [Susan Holmes](https://statweb.stanford.edu/~susan/) are also well worth taking a look.
 
-- [Monte Carlo theory, methods and examples](https://artowen.su.domains/mc/) by [Professor Art Owen](https://statweb.stanford.edu/~owen/), gives a nice and complete treatment of all the topics on simulation, including a whole chapter on variance reduction. 
+- [Monte Carlo theory, methods and examples](https://artowen.su.domains/mc/) by [Professor Art Owen](https://artowen.su.domains/), gives a nice and complete treatment of all the topics on simulation, including a whole chapter on variance reduction. 
 
 Other materials, including lecture notes and slides may be posted here as the course progresses. 
 


### PR DESCRIPTION
Professor Art Owen's personal website has a [new domain](https://artowen.su.domains/); it appears that the [old one](https://statweb.stanford.edu/~owen/) is no longer online. 

By the way, thanks for sharing! This repository in general (and Owen's book in particular) is a gem for everything related to computational statistics. 😄 
 
![image](https://github.com/maxbiostat/Computational_Statistics/assets/64290445/58be8068-9375-4fd5-918a-7be25a9cdb8a)
